### PR TITLE
adds flags to allow the creation of shared rendertargets

### DIFF
--- a/Core/DX11/Rendering/DX11ResourcePoolManager.cs
+++ b/Core/DX11/Rendering/DX11ResourcePoolManager.cs
@@ -39,9 +39,9 @@ namespace FeralTic.DX11
             return this.targetpool.Lock(w, h, format, new SampleDescription(1, 0), genMM, mmLevels, singleframe);
         }
 
-        public DX11ResourcePoolEntry<DX11RenderTarget2D> LockRenderTarget(int w, int h, Format format, SampleDescription sd, bool genMM = false, int mmLevels = 1)
+        public DX11ResourcePoolEntry<DX11RenderTarget2D> LockRenderTarget(int w, int h, Format format, SampleDescription sd, bool genMM = false, int mmLevels = 1, bool shared=false)
         {
-            return this.targetpool.Lock(w, h, format, sd, genMM, mmLevels);
+            return this.targetpool.Lock(w, h, format, sd, genMM, mmLevels, true, shared);
         }
 
         public DX11ResourcePoolEntry<IDX11RWStructureBuffer> LockStructuredBuffer(int stride, int numelements, eDX11BufferMode mode = eDX11BufferMode.Default, bool oneframe = false)

--- a/Core/DX11/Rendering/DX11ResourcePools.cs
+++ b/Core/DX11/Rendering/DX11ResourcePools.cs
@@ -52,7 +52,7 @@ namespace FeralTic.DX11
 
         }
 
-        public DX11ResourcePoolEntry<DX11RenderTarget2D> Lock(int w, int h, Format format, SampleDescription sd, bool genMM = false, int mmLevels = 1, bool oneframe = true)
+        public DX11ResourcePoolEntry<DX11RenderTarget2D> Lock(int w, int h, Format format, SampleDescription sd, bool genMM = false, int mmLevels = 1, bool oneframe = true, bool shared = false)
         {
             foreach (DX11ResourcePoolEntry<DX11RenderTarget2D> entry in this.pool)
             {
@@ -61,14 +61,14 @@ namespace FeralTic.DX11
                 if (!entry.IsLocked && tr.Width == w && tr.Format == format && tr.Height == h
                     && tr.Resource.Description.SampleDescription.Count == sd.Count
                     && tr.Resource.Description.SampleDescription.Quality == sd.Quality
-                    && tr.GenMipMaps == genMM && tr.RequestedMipLevels == mmLevels)
+                    && tr.GenMipMaps == genMM && tr.RequestedMipLevels == mmLevels && tr.Shared == shared)
                 {
                     entry.Lock();
                     return entry;
                 }
             }
 
-            DX11RenderTarget2D res = new DX11RenderTarget2D(this.context, w, h,sd, format, genMM, mmLevels);
+            DX11RenderTarget2D res = new DX11RenderTarget2D(this.context, w, h,sd, format, genMM, mmLevels, false, shared);
 
             DX11ResourcePoolEntry<DX11RenderTarget2D> newentry = new DX11ResourcePoolEntry<DX11RenderTarget2D>(res);
 

--- a/Core/DX11/Resources/Textures/2d/DX11RenderTarget2D.cs
+++ b/Core/DX11/Resources/Textures/2d/DX11RenderTarget2D.cs
@@ -15,6 +15,7 @@ namespace FeralTic.DX11.Resources
         private UnorderedAccessView uav;
         private bool allowuav;
         private bool genmm;
+        private bool shared;
         private int requestedMipsLevel;
 
         public bool GenMipMaps
@@ -25,6 +26,11 @@ namespace FeralTic.DX11.Resources
         public int RequestedMipLevels
         {
             get { return this.requestedMipsLevel; }
+        }
+
+        public bool Shared
+        {
+            get { return this.shared; }
         }
 
         public UnorderedAccessView UAV
@@ -59,6 +65,7 @@ namespace FeralTic.DX11.Resources
         public DX11RenderTarget2D(DX11RenderContext context, int w, int h, SampleDescription sd, Format format, bool genMipMaps, int mmLevels, bool allowUAV, bool allowShare)
         {
             this.context = context;
+            this.shared = allowShare;
             var texBufferDesc = new Texture2DDescription
             {
                 ArraySize = 1,
@@ -82,7 +89,7 @@ namespace FeralTic.DX11.Resources
 
             if (sd.Count == 1 && genMipMaps == false && allowShare)
             {
-                texBufferDesc.OptionFlags = ResourceOptionFlags.KeyedMutex;
+                texBufferDesc.OptionFlags = /*ResourceOptionFlags.KeyedMutex |*/ ResourceOptionFlags.Shared;
             }
 
             if (genMipMaps && sd.Count == 1)


### PR DESCRIPTION
This changes the meaning of allowShared in the creation of RenderTargets which seemed to not be used anywhere in the code from `ResourceOptionFlags.KeyedMutex` to `ResourceOptionFlags.Shared` allowing to share the texture between different contexts. I'm sending another PR to vvvv-dx11 which complements this allowing to create a TempTargetRenderer which uses shared render targets
