### PR TITLE
Changes to shader include behavior

### DIFF
--- a/Core/DX11/Shaders/DX11Effect.cs
+++ b/Core/DX11/Shaders/DX11Effect.cs
@@ -51,19 +51,16 @@ namespace FeralTic.DX11
 
             if (type == IncludeType.Local)
             {
-                string ppath = this.BaseShaderPath;
                 FileStream ps = parentStream as FileStream;
 
-                if( ps != null ){
-                    ppath = ppath = Path.GetDirectoryName(ps.Name);
-                }
-
                 // Attempt to include relative to current file
-                path = Path.Combine(ppath, fileName);
-                if (File.Exists(path))
-                {
-                    stream = new FileStream(path, FileMode.Open, FileAccess.Read);
-                    return;
+                if( ps != null ){
+                    path = Path.Combine(Path.GetDirectoryName(ps.Name), fileName);
+                    if (File.Exists(path))
+                    {
+                        stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+                        return;
+                    }
                 }
                 
                 // Attempt to include relative to origin file

--- a/Core/DX11/Shaders/DX11Effect.cs
+++ b/Core/DX11/Shaders/DX11Effect.cs
@@ -47,39 +47,43 @@ namespace FeralTic.DX11
 
         public void Open(IncludeType type, string fileName, Stream parentStream, out Stream stream)
         {
+            string path;
+
             if (type == IncludeType.Local)
             {
-                string path = this.BaseShaderPath + "\\" + fileName;
+                string ppath = this.BaseShaderPath;
+                FileStream ps = parentStream as FileStream;
+
+                if( ps != null ){
+                    ppath = ppath = Path.GetDirectoryName(ps.Name);
+                }
+
+                // Attempt to include relative to current file
+                path = Path.Combine(ppath, fileName);
                 if (File.Exists(path))
                 {
-                    string content = File.ReadAllText(path);
-                    stream = new MemoryStream();
-                    StreamWriter writer = new StreamWriter(stream);
-                    writer.Write(content);
-                    writer.Flush();
-                    stream.Position = 0;
+                    stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+                    return;
                 }
-                else
+                
+                // Attempt to include relative to origin file
+                path = Path.Combine(this.BaseShaderPath, fileName);
+                if (File.Exists(path))
                 {
-                    stream = null;
+                    stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+                    return;
                 }
+            }
+
+            // If system type include or if the file was not found for a local include
+            path = Path.Combine(this.sysincludepath, fileName);
+            if (File.Exists(path))
+            {
+                stream = new FileStream(path, FileMode.Open, FileAccess.Read);
             }
             else
             {
-                string path = Path.Combine(this.sysincludepath, fileName);
-                if (File.Exists(path))
-                {
-                    string content = File.ReadAllText(path);
-                    stream = new MemoryStream();
-                    StreamWriter writer = new StreamWriter(stream);
-                    writer.Write(content);
-                    writer.Flush();
-                    stream.Position = 0;
-                }
-                else
-                {
-                    stream = null;
-                }
+                stream = null;
             }
         }
     }


### PR DESCRIPTION
local includes are handled in a way that is more consistent with what is
expected from C style includes.
Local includes are first attempted relative to the file they are being
included into, followed by relative to the origin shader file, followed
by the system include path.

Push of relevant changes to dx11-vvvv pending.