### PR TITLE
Method to return a DX11Texture2D from memory with ImageLoadInformation

### DIFF
--- a/Core/DX11/Resources/Textures/2d/DX11Texture2D.cs
+++ b/Core/DX11/Resources/Textures/2d/DX11Texture2D.cs
@@ -90,9 +90,14 @@ namespace FeralTic.DX11.Resources
 
         public static DX11Texture2D FromMemory(DX11RenderContext context, byte[] data)
         {
+            return FromMemory(context, data, ImageLoadInformation.FromDefaults());
+        }
+
+        public static DX11Texture2D FromMemory(DX11RenderContext context, byte[] data, ImageLoadInformation loadinfo)
+        {
             try
             {
-                Texture2D tex = Texture2D.FromMemory(context.Device, data);
+                Texture2D tex = Texture2D.FromMemory(context.Device, data, loadinfo);
 
                 if (tex.Description.ArraySize == 1)
                 {


### PR DESCRIPTION
- Useful for disabling mipmaps when loading textures from in-memory data.