### PR TITLE
Corrected data stream size for line with normals

### DIFF
--- a/Core/DX11/Geometry/Primitives/DX11Primitive_Line.cs
+++ b/Core/DX11/Geometry/Primitives/DX11Primitive_Line.cs
@@ -139,7 +139,7 @@ namespace FeralTic.DX11.Geometry
             }
 
 
-            DataStream ds = new DataStream(vcount * Pos3Tex2Vertex.VertexSize, true, true);
+            DataStream ds = new DataStream(vcount * Pos3Norm3Tex2Vertex.VertexSize, true, true);
             ds.Position = 0;
             ds.WriteRange(verts);
             ds.Position = 0;


### PR DESCRIPTION
was using the vertex layout size form the method without normals...