### PR TITLE
Fix for crash when generating the nodelist.xml file

### DIFF
--- a/Core/DX11/Scheduler/DX11SchedulerThread.cs
+++ b/Core/DX11/Scheduler/DX11SchedulerThread.cs
@@ -35,6 +35,12 @@ namespace FeralTic.DX11
         public void Stop()
         {
             this.running = false;
+            if (this.thr != null)
+            {
+                // Wait for the thread to terminate. Prevents a ExecutionEngineException after generating the nodelist.xml
+                if (this.thr.Join(1000))
+                    this.thr = null;
+            }
         }
 
         private void Run()


### PR DESCRIPTION
Hey vux!

I just stumbled upon this when generating our nodelist.xml file. I had your pack installed and on vvvv shutdown I got a very nasty ExecutionEngineException. By waiting on the scheduler thread to terminate gracefully the exception did not occur again.

All the best,
Elias